### PR TITLE
Default values on domains for records

### DIFF
--- a/powerdns/migrations/0010_domain_record_auto_ptr.py
+++ b/powerdns/migrations/0010_domain_record_auto_ptr.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import dj.choices.fields
+import powerdns.utils
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('powerdns', '0009_auto_20150915_0342'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='domain',
+            name='record_auto_ptr',
+            field=dj.choices.fields.ChoiceField(default=2, choices=powerdns.utils.AutoPtrOptions),
+        ),
+    ]

--- a/powerdns/templates/admin/powerdns/change_form.html
+++ b/powerdns/templates/admin/powerdns/change_form.html
@@ -1,0 +1,7 @@
+{% extends "admin/change_form.html" %}
+{% block object-tools-items %}
+{{ block.super }}
+{% for btn in original.extra_buttons %} 
+<li><a href="{{ btn.0 }}">{{ btn.1 }}</a></li>
+{% endfor %}
+{% endblock %}


### PR DESCRIPTION
You can now add to domain default values (currently auto_ptr, but the mechanism is easily extensible) that would be pre-filled on a new record form if you click 'add record' on domain table view or single domain view.