### PR TITLE
Fixed CircleCI errors

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
         - docker
 dependencies:
     override:
-        - pip install docker-compose
+        - pip install docker-compose==1.2.0
 test:
     override:
         - cd integration-tests && docker-compose run runner

--- a/integration-tests/test/test_creation.py
+++ b/integration-tests/test/test_creation.py
@@ -14,15 +14,13 @@ class TestCreation(TestBase):
                 'template': 'http://dnsaas:8080/api/domain-templates/1/',
             }
         )
-        print(domain_create_rq.status_code)
-        print(domain_create_rq.text)
         self.domain_url = domain_create_rq.headers['Location']
         record_create_rq = self.post(
             'http://dnsaas:8080/api/records/', data={
                 'type': 'A',
                 'name': 'www.example2.com',
                 'content': '192.168.2.11',
-                'auto_ptr': '1',
+                'auto_ptr': 2,
                 'domain': self.domain_url,
             }
         )

--- a/integration-tests/test/test_serial.py
+++ b/integration-tests/test/test_serial.py
@@ -22,7 +22,7 @@ class TestSerial(TestBase):
             'http://dnsaas:8080/api/domains/',
             {'name': 'example.com'}
         )
-        domain_url = get_domain_request.json()[0]['url']
+        domain_url = get_domain_request.json()['results'][0]['url']
         create_record_request = self.post(
             'http://dnsaas:8080/api/records/',
             {


### PR DESCRIPTION
Due to changes on CircleCI the integration tests started to fail. Also
changes for auto_ptr were missed. These correct these errors.

* Forced docker-compose version
* auto_ptr uses 2=ALWAYS instead of 1=True
* Using paginated data