### PR TITLE
Authorisations added

### DIFF
--- a/dnsaas/settings.py
+++ b/dnsaas/settings.py
@@ -136,6 +136,7 @@ INSTALLED_APPS = (
     'rest_framework_swagger',
     'powerdns',
     'dnsaas',
+    'autocomplete_light',
     'django.contrib.admin',
     'django.contrib.admindocs',
     'rules',

--- a/dnsaas/urls.py
+++ b/dnsaas/urls.py
@@ -1,4 +1,5 @@
 
+import autocomplete_light.shortcuts as al
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
 from django.conf import settings
@@ -17,10 +18,10 @@ from powerdns.views import (
     RecordTemplateViewSet,
 )
 
-admin.autodiscover()
-
 title = settings.SITE_TITLE
 title_v = ' '.join([title, VERSION])
+
+al.autodiscover()
 
 admin.site.site_title = title
 admin.site.site_header = title_v
@@ -43,4 +44,5 @@ urlpatterns = patterns(
     url(r'^api/', include(router.urls)),
     url(r'^api-token-auth/', obtain_auth_token),
     url(r'^api-docs/', include('rest_framework_swagger.urls')),
+    url(r'^autocomplete/', include('autocomplete_light.urls')),
 )

--- a/powerdns/__init__.py
+++ b/powerdns/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'powerdns.apps.Powerdns'

--- a/powerdns/apps.py
+++ b/powerdns/apps.py
@@ -1,0 +1,31 @@
+from django.apps import AppConfig
+from django.contrib.auth.models import User
+
+
+class Powerdns(AppConfig):
+
+    name = 'powerdns'
+    verbose_name = 'PowerDNS'
+
+    def ready(self):
+        import autocomplete_light.shortcuts as al
+        from powerdns.models.powerdns import Domain, Record
+
+        class AutocompleteAuthItems(al.AutocompleteGenericBase):
+            choices = (
+                Domain.objects.all(),
+                Record.objects.all(),
+            )
+            search_fields = (
+                ('name',),
+                ('name',)
+            )
+
+        al.register(AutocompleteAuthItems)
+        # We register the default django User class. If someone wants to use
+        # an alternative user model, she needs to register it herself. We can't
+        # do it, as we don't know what fields are used there.
+        al.register(
+            User,
+            search_fields=['username', 'first_name', 'last_name']
+        )

--- a/powerdns/migrations/0011_auto_20151103_0546.py
+++ b/powerdns/migrations/0011_auto_20151103_0546.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+import django.core.validators
+import powerdns.models.powerdns
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('powerdns', '0010_auto_20150921_0613'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Authorisation',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('target_id', models.PositiveIntegerField()),
+                ('authorised', models.ForeignKey(related_name='received_authorisations', to=settings.AUTH_USER_MODEL)),
+                ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
+                ('owner', models.ForeignKey(related_name='issued_authorisations', to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+        migrations.AlterField(
+            model_name='domain',
+            name='name',
+            field=models.CharField(verbose_name='name', unique=True, max_length=255, validators=[django.core.validators.RegexValidator('^(\\*\\.)?([_A-Za-z0-9-]+\\.)*([A-Za-z0-9])+$'), powerdns.models.powerdns.SubDomainValidator()]),
+        ),
+    ]

--- a/powerdns/models/__init__.py
+++ b/powerdns/models/__init__.py
@@ -1,2 +1,3 @@
 from powerdns.models.powerdns import *  # noqa
 from powerdns.models.templates import *  # noqa
+from powerdns.models.authorisations import *  # noqa

--- a/powerdns/models/authorisations.py
+++ b/powerdns/models/authorisations.py
@@ -1,0 +1,43 @@
+import rules
+from django.conf import settings
+from django.db import models
+from django.contrib.contenttypes.fields import ContentType
+from django.contrib.contenttypes.fields import GenericForeignKey
+
+from powerdns.utils import is_owner
+
+
+class Authorisation(models.Model):
+    """A revokable allowance to access / edit domains / records"""
+
+    owner = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=False,
+        blank=False,
+        related_name='issued_authorisations',
+    )
+    authorised = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=False,
+        blank=False,
+        related_name='received_authorisations',
+    )
+    content_type = models.ForeignKey(ContentType)
+    target_id = models.PositiveIntegerField()
+    target = GenericForeignKey('content_type', 'target_id')
+
+    def __str__(self):
+        return '{} authorised {} to {}'.format(
+            self.owner,
+            self.authorised,
+            self.target,
+        )
+
+
+rules.add_perm('powerdns.add_authorisation', rules.is_authenticated)
+rules.add_perm(
+    'powerdns.change_authorisation', (rules.is_superuser | is_owner)
+)
+rules.add_perm(
+    'powerdns.delete_authorisation', (rules.is_superuser | is_owner)
+)

--- a/powerdns/templates/admin/base_site.html
+++ b/powerdns/templates/admin/base_site.html
@@ -1,0 +1,15 @@
+{% extends "admin/base.html" %}
+
+{% block title %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
+
+{% block branding %}
+<h1 id="site-name"><a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a></h1>
+{% endblock %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.js" type="text/javascript"></script>
+    {% include 'autocomplete_light/static.html' %}
+{% endblock %}
+
+{% block nav-global %}{% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
     install_requires = [
         'Django>=1.8',
         'IPy>=0.82a',
+        'django-autocomplete-light>=2.2.10',
         'django-extensions>=1.5.5',
         'django-nose>=1.4',
         'dj.choices>=0.10.0',


### PR DESCRIPTION
An 'authorisation' object can be created. Users that have
'authorisation' object issued for them have the same permissions as
owners except the ability to issue new authorisations.