### PR TITLE
Owner no longer changes when accepting request

### DIFF
--- a/powerdns/admin.py
+++ b/powerdns/admin.py
@@ -332,7 +332,16 @@ class DeleteRequestAdmin(ObjectPermissionsModelAdmin):
     fields = ['owner', 'target_id', 'content_type']
 
 
+class RecordRequestForm(autocomplete_light.ModelForm):
+    class Meta:
+        widgets = {
+            'state': HiddenInput(),
+            'owner': HiddenInput(),
+        }
+
+
 class RecordRequestAdmin(CopyingAdmin):
+    form = RecordRequestForm
     list_display = RECORD_LIST_FIELDS
     from_field = 'record'
     FromModel = Record

--- a/powerdns/tests/test_requests.py
+++ b/powerdns/tests/test_requests.py
@@ -1,5 +1,7 @@
 import unittest
 
+from django.contrib.auth.models import User
+
 from powerdns.models.powerdns import Domain, Record
 from powerdns.models.requests import DomainRequest, RecordRequest
 from powerdns.tests.utils import assert_does_exist, assert_not_exists
@@ -9,38 +11,54 @@ class TestRequests(unittest.TestCase):
     """Tests for domain/record requests"""
 
     def setUp(self):
+        self.user1 = User.objects.create_user(
+            'user1', 'user1@example.com', 'password'
+        )
+        self.user2 = User.objects.create_user(
+            'user2', 'user2@example.com', 'password'
+        )
         self.domain = Domain.objects.create(
             name='example.com',
             type='NATIVE',
+            owner=self.user1
         )
         self.record = Record.objects.create(
             domain=self.domain,
             name='forum.example.com',
             type='CNAME',
-            content='phpbb.example.com'
-
+            content='phpbb.example.com',
+            owner=self.user1,
         )
 
     def tearDown(self):
-        for Model in [Domain, DomainRequest, Record, RecordRequest]:
+        for Model in [Domain, DomainRequest, Record, RecordRequest, User]:
             Model.objects.all().delete()
 
     def test_subdomain_creation(self):
         request = DomainRequest.objects.create(
             parent_domain=self.domain,
-            name='subdomain.example.com'
+            name='subdomain.example.com',
+            owner=self.user1,
         )
         request.accept()
-        assert_does_exist(Domain, name='subdomain.example.com')
+        assert_does_exist(
+            Domain, name='subdomain.example.com', owner=self.user1
+        )
 
     def test_domain_change(self):
         request = DomainRequest.objects.create(
             domain=self.domain,
             name='example.com',
             type='MASTER',
+            owner=self.user2,
         )
         request.accept()
-        assert_does_exist(Domain, name='example.com', type='MASTER')
+        assert_does_exist(
+            Domain,
+            name='example.com',
+            type='MASTER',
+            owner=self.user1
+        )
         assert_not_exists(Domain, name='example.com', type='NATIVE')
 
     def test_record_creation(self):


### PR DESCRIPTION
Previous bug caused owner of a record/domain to be set to the owner of
the request (the one that issued it). This is now corrected. Only new
records/domains are owned by the requestor.