### PR TITLE
Setting the reverse domain type

### DIFF
--- a/powerdns/models/powerdns.py
+++ b/powerdns/models/powerdns.py
@@ -570,10 +570,13 @@ class Record(TimeTrackable, Owned, WithRequests):
         if self.auto_ptr == AutoPtrOptions.ALWAYS:
             domain, created = Domain.objects.get_or_create(
                 name=domain_name,
-                defaults={'template': (
-                    self.domain.reverse_template or
-                    get_default_reverse_domain()
-                )}
+                defaults={
+                    'template': (
+                        self.domain.reverse_template or
+                        get_default_reverse_domain()
+                    ),
+                    'type': self.domain.type,
+                }
             )
         elif self.auto_ptr == AutoPtrOptions.ONLY_IF_DOMAIN:
             try:

--- a/powerdns/tests/test_auto_ptr.py
+++ b/powerdns/tests/test_auto_ptr.py
@@ -33,7 +33,7 @@ class TestAutoPtr(TestCase):
             ),
             domain_template = self.reverse_template,
         )
-        self.alt_soar_record = RecordTemplateFactory(
+        self.alt_soa_record = RecordTemplateFactory(
             type='SOA',
             name='{domain-name}',
             content=(
@@ -46,6 +46,7 @@ class TestAutoPtr(TestCase):
             name='example.com',
             template=None,
             reverse_template=None,
+            type='NATIVE',
         )
 
     def test_default_ptr_created(self):
@@ -59,6 +60,7 @@ class TestAutoPtr(TestCase):
             owner=self.user,
         )
         domain = Domain.objects.get(name='1.168.192.in-addr.arpa')
+        self.assertEqual(domain.type, 'NATIVE')
         self.assertTrue(domain.get_soa().content.endswith('600'))
         assert_does_exist(
             Record,


### PR DESCRIPTION
If the reverse domain type is to be created, it inherits its name from
the domain where the A record was created
