### PR TITLE
Added unrestricted flag to domains

### DIFF
--- a/powerdns/admin.py
+++ b/powerdns/admin.py
@@ -34,7 +34,7 @@ from powerdns.models.requests import (
     DomainRequest,
     RecordRequest,
 )
-from powerdns.utils import Owned, PermissionValidator, is_owner
+from powerdns.utils import Owned, DomainForRecordValidator, is_owner
 
 
 class NullBooleanRadioSelect(NullBooleanSelect, AdminRadioSelect):
@@ -86,7 +86,7 @@ class RecordAdminForm(ModelForm):
             # Domain unchanged. Maybe user was assigned the record in a domain
             # She doesn't own.
             return self.cleaned_data['domain']
-        validator = PermissionValidator('powerdns.change_domain')
+        validator = DomainForRecordValidator()
         validator.user = self.user
         return validator(self.cleaned_data['domain'])
 

--- a/powerdns/migrations/0015_auto_20151214_0632.py
+++ b/powerdns/migrations/0015_auto_20151214_0632.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.core.validators
+import powerdns.models.powerdns
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('powerdns', '0014_auto_20151124_0505'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='domain',
+            name='unrestricted',
+            field=models.BooleanField(default=False, verbose_name='Unrestricted', help_text="Can users that are not owners of this domain add recordsto it without owner's permission?"),
+        ),
+        migrations.AddField(
+            model_name='domainrequest',
+            name='unrestricted',
+            field=models.BooleanField(default=False, verbose_name='Unrestricted', help_text="Can users that are not owners of this domain add recordsto it without owner's permission?"),
+        ),
+        migrations.AddField(
+            model_name='domaintemplate',
+            name='unrestricted',
+            field=models.BooleanField(default=False, verbose_name='Unrestricted', help_text="Can users that are not owners of this domain add recordsto it without owner's permission?"),
+        ),
+        migrations.AlterField(
+            model_name='domain',
+            name='name',
+            field=models.CharField(max_length=255, validators=[django.core.validators.RegexValidator('^(\\*\\.)?([_A-Za-z0-9-]+\\.)*([A-Za-z0-9])+$'), powerdns.models.powerdns.SubDomainValidator()], unique=True, verbose_name='name'),
+        ),
+    ]

--- a/powerdns/models/powerdns.py
+++ b/powerdns/models/powerdns.py
@@ -279,6 +279,16 @@ class Domain(TimeTrackable, Owned, WithRequests):
         )
     )
 
+    unrestricted = models.BooleanField(
+        _('Unrestricted'),
+        null=False,
+        default=False,
+        help_text=_(
+            "Can users that are not owners of this domain add records"
+            "to it without owner's permission?"
+        )
+    )
+
     class Meta:
         db_table = u'domains'
         verbose_name = _("domain")
@@ -314,7 +324,7 @@ class Domain(TimeTrackable, Owned, WithRequests):
     def add_record_link(self):
         authorised = get_current_user().has_perm(
             'powerdns.change_domain', self
-        )
+        ) or self.unrestricted
         return '<a href="{}">{}</a>'.format(
             self.add_record_url(authorised),
             ('Add record' if authorised else 'Request record')

--- a/powerdns/models/requests.py
+++ b/powerdns/models/requests.py
@@ -174,6 +174,16 @@ class DomainRequest(ChangeCreateRequest):
             'Should A records have auto PTR by default'
         )
     )
+    unrestricted = models.BooleanField(
+        _('Unrestricted'),
+        null=False,
+        default=False,
+        help_text=_(
+            "Can users that are not owners of this domain add records"
+            "to it without owner's permission?"
+        )
+    )
+
     view = 'accept_domain'
 
     def __str__(self):

--- a/powerdns/models/templates.py
+++ b/powerdns/models/templates.py
@@ -31,6 +31,16 @@ class DomainTemplate(models.Model):
         _("type"), max_length=6, blank=True, null=True,
         choices=Domain.DOMAIN_TYPE, help_text=_("Record type"),
     )
+    unrestricted = models.BooleanField(
+        _('Unrestricted'),
+        null=False,
+        default=False,
+        help_text=_(
+            "Can users that are not owners of this domain add records"
+            "to it without owner's permission?"
+        )
+    )
+
     record_auto_ptr = ChoiceField(
         choices=AutoPtrOptions,
         default=AutoPtrOptions.ALWAYS,

--- a/powerdns/serializers.py
+++ b/powerdns/serializers.py
@@ -15,7 +15,7 @@ from rest_framework.serializers import(
     HyperlinkedRelatedField,
     SlugRelatedField,
 )
-from powerdns.utils import PermissionValidator
+from powerdns.utils import DomainForRecordValidator
 
 
 class OwnerSerializer(HyperlinkedModelSerializer):
@@ -44,7 +44,7 @@ class RecordSerializer(OwnerSerializer):
     domain = HyperlinkedRelatedField(
         queryset=Domain.objects.all(),
         view_name='domain-detail',
-        validators=[PermissionValidator('powerdns.change_domain')],
+        validators=[DomainForRecordValidator()],
     )
 
 

--- a/powerdns/tests/test_auto_ptr.py
+++ b/powerdns/tests/test_auto_ptr.py
@@ -49,6 +49,10 @@ class TestAutoPtr(TestCase):
             type='NATIVE',
         )
 
+    def tearDown(self):
+        for Model in [Domain, Record, User]:
+            Model.objects.all().delete()
+
     def test_default_ptr_created(self):
         """A PTR record is created for an A record with default template"""
         RecordFactory(

--- a/powerdns/tests/test_events.py
+++ b/powerdns/tests/test_events.py
@@ -3,6 +3,7 @@
 
 from powerdns.models import Record
 from powerdns.tests.utils import RecordTestCase, RecordFactory
+from powerdns.utils import AutoPtrOptions
 
 
 class TestSOASerialUpdate(RecordTestCase):
@@ -28,12 +29,14 @@ class TestSOASerialUpdate(RecordTestCase):
             type='A',
             name='www.example.com',
             content='192.168.1.1',
+            auto_ptr=AutoPtrOptions.NEVER,
         )
         self.cname_record = RecordFactory(
             domain=self.domain,
             type='CNAME',
             name='blog.example.com',
             content='www.example.com',
+            auto_ptr=AutoPtrOptions.NEVER,
         )
 
     def test_soa_update(self):

--- a/powerdns/tests/test_ownership.py
+++ b/powerdns/tests/test_ownership.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import User
 from django.core import mail
 from django.test import TestCase
 
+from powerdns.models.powerdns import Domain, Record
 from powerdns.tests.utils import DomainFactory, user_client
 
 
@@ -21,6 +22,10 @@ class TestOwnershipBase(TestCase):
         )
         self.client = user_client(self.user1)
         mail.outbox = []
+
+    def tearDown(self):
+        for Model in [Domain, Record, User]:
+            Model.objects.all().delete()
 
     def assertOwner(self, request, username, mailed):
         """Assert the owner in returned data is username and he

--- a/powerdns/tests/test_permissions.py
+++ b/powerdns/tests/test_permissions.py
@@ -38,6 +38,11 @@ class TestPermissions(TestCase):
             name='su.example.com',
             owner=self.superuser,
         )
+        self.unrestricted_domain = DomainFactory(
+            name='unrestricted.example.com',
+            owner=self.superuser,
+            unrestricted=True,
+        )
         self.u_domain = DomainFactory(
             name='u.example.com',
             owner=self.user,
@@ -184,6 +189,21 @@ class TestPermissions(TestCase):
                 'content': '192.168.1.4',
                 'type': 'A',
                 'domain': get_domain_url(self.u_domain),
+                'auto_ptr': AutoPtrOptions.NEVER.id,
+            },
+        )
+        self.assertEqual(request.status_code, 201)
+
+    def test_user_can_create_records_in_unrestricted_domain(self):
+        """Normal user can create records in domain that is marked as
+        'unrestricted'."""
+        request = self.u_client.post(
+            reverse('record-list'),
+            {
+                'name': 'site.u.example.com',
+                'content': '192.168.1.4',
+                'type': 'A',
+                'domain': get_domain_url(self.unrestricted_domain),
                 'auto_ptr': AutoPtrOptions.NEVER.id,
             },
         )

--- a/powerdns/tests/test_requests.py
+++ b/powerdns/tests/test_requests.py
@@ -68,6 +68,7 @@ class TestRequests(unittest.TestCase):
             type='CNAME',
             name='site.example.com',
             content='www.example.com',
+            owner=self.user1
         )
         request.accept()
         assert_does_exist(Record, content='www.example.com')

--- a/powerdns/tests/utils.py
+++ b/powerdns/tests/utils.py
@@ -9,6 +9,7 @@ from rest_framework.test import APIClient
 
 from powerdns.models.powerdns import Record, Domain
 from powerdns.models.templates import RecordTemplate, DomainTemplate
+from powerdns.utils import AutoPtrOptions
 
 
 class DomainFactory(DjangoModelFactory):
@@ -35,7 +36,10 @@ class RecordTestCase(TestCase):
     """Base class for tests on records."""
 
     def setUp(self):
-        self.domain = DomainFactory(name='example.com', template=None)
+        self.domain = DomainFactory(
+            name='example.com',
+            template=None,
+        )
 
     def validate(self, **values):
         """

--- a/powerdns/utils.py
+++ b/powerdns/utils.py
@@ -117,6 +117,19 @@ class PermissionValidator():
         return object_
 
 
+class DomainForRecordValidator(PermissionValidator):
+    """A validator for 'domain' field in record forms and API"""
+    def __init__(self, *args, **kwargs):
+        super().__init__('powerdns.change_domain', *args, **kwargs)
+    
+
+    def __call__(self, object_):
+        if object_.unrestricted:
+            return object_
+        else:
+            return super().__call__(object_)
+
+
 def to_reverse(ip):
     """
     Given an ip address it will return a tuple of (domain, number)


### PR DESCRIPTION
Domains can now be marked as 'unrestricted'. These can have records
added without permission from owner.
