### PR TITLE
Added possibility to change owner by request

### DIFF
--- a/powerdns/admin.py
+++ b/powerdns/admin.py
@@ -93,6 +93,9 @@ class RecordAdminForm(ModelForm):
 
 class CopyingAdmin(admin.ModelAdmin):
 
+    field_prefix = ''
+    target_prefix = ''
+
     def get_form(self, request, obj=None, **kwargs):
         form = super().get_form(request, obj, **kwargs)
         from_pk = request.GET.get(self.from_field)
@@ -100,7 +103,7 @@ class CopyingAdmin(admin.ModelAdmin):
             from_object = self.FromModel.objects.get(pk=from_pk)
             for field in self.CopyFieldsModel.copy_fields:
                 form.base_fields[field[len(self.field_prefix):]].initial = \
-                    getattr(from_object, field)
+                    getattr(from_object, field[len(self.target_prefix):])
         return form
 
 
@@ -203,7 +206,6 @@ class DomainAdmin(OwnedAdmin, CopyingAdmin):
     readonly_fields = ('notified_serial', 'created', 'modified')
     FromModel = DomainTemplate
     CopyFieldsModel = DomainTemplate
-    field_prefix = ''
     from_field = 'template'
 
 
@@ -279,11 +281,11 @@ class DomainRequestForm(autocomplete_light.ModelForm):
 
 class DomainRequestAdmin(CopyingAdmin):
     form = DomainRequestForm
-    list_display = ['name']
+    list_display = ['domain']
     from_field = 'domain'
     FromModel = Domain
     CopyFieldsModel = DomainRequest
-    field_prefix = ''
+    target_prefix = 'target_'
     readonly_fields = ['key']
 
 
@@ -350,11 +352,11 @@ class RecordRequestForm(autocomplete_light.ModelForm):
 
 class RecordRequestAdmin(CopyingAdmin):
     form = RecordRequestForm
-    list_display = RECORD_LIST_FIELDS
+    list_display = ['target_' + field for field in RECORD_LIST_FIELDS]
     from_field = 'record'
     FromModel = Record
     CopyFieldsModel = RecordRequest
-    field_prefix = ''
+    target_prefix = 'target_'
 
 
 admin.site.register(Domain, DomainAdmin)

--- a/powerdns/migrations/0019_auto_20160111_0842.py
+++ b/powerdns/migrations/0019_auto_20160111_0842.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('powerdns', '0018_auto_20160105_0824'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='domainrequest',
+            old_name='account',
+            new_name='target_account',
+        ),
+        migrations.RenameField(
+            model_name='domainrequest',
+            old_name='master',
+            new_name='target_master',
+        ),
+        migrations.RenameField(
+            model_name='domainrequest',
+            old_name='name',
+            new_name='target_name',
+        ),
+        migrations.RenameField(
+            model_name='domainrequest',
+            old_name='record_auto_ptr',
+            new_name='target_record_auto_ptr',
+        ),
+        migrations.RenameField(
+            model_name='domainrequest',
+            old_name='remarks',
+            new_name='target_remarks',
+        ),
+        migrations.RenameField(
+            model_name='domainrequest',
+            old_name='reverse_template',
+            new_name='target_reverse_template',
+        ),
+        migrations.RenameField(
+            model_name='domainrequest',
+            old_name='template',
+            new_name='target_template',
+        ),
+        migrations.RenameField(
+            model_name='domainrequest',
+            old_name='type',
+            new_name='target_type',
+        ),
+        migrations.RenameField(
+            model_name='domainrequest',
+            old_name='unrestricted',
+            new_name='target_unrestricted',
+        ),
+        migrations.RenameField(
+            model_name='recordrequest',
+            old_name='auth',
+            new_name='target_auth',
+        ),
+        migrations.RenameField(
+            model_name='recordrequest',
+            old_name='content',
+            new_name='target_content',
+        ),
+        migrations.RenameField(
+            model_name='recordrequest',
+            old_name='disabled',
+            new_name='target_disabled',
+        ),
+        migrations.RenameField(
+            model_name='recordrequest',
+            old_name='name',
+            new_name='target_name',
+        ),
+        migrations.RenameField(
+            model_name='recordrequest',
+            old_name='ordername',
+            new_name='target_ordername',
+        ),
+        migrations.RenameField(
+            model_name='recordrequest',
+            old_name='prio',
+            new_name='target_prio',
+        ),
+        migrations.RenameField(
+            model_name='recordrequest',
+            old_name='remarks',
+            new_name='target_remarks',
+        ),
+        migrations.RenameField(
+            model_name='recordrequest',
+            old_name='ttl',
+            new_name='target_ttl',
+        ),
+        migrations.RenameField(
+            model_name='recordrequest',
+            old_name='type',
+            new_name='target_type',
+        ),
+        migrations.AddField(
+            model_name='domainrequest',
+            name='target_owner',
+            field=models.ForeignKey(null=True, verbose_name='Owner', related_name='+', to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AddField(
+            model_name='recordrequest',
+            name='target_owner',
+            field=models.ForeignKey(null=True, verbose_name='Owner', related_name='+', to=settings.AUTH_USER_MODEL),
+        ),
+    ]

--- a/powerdns/models/powerdns.py
+++ b/powerdns/models/powerdns.py
@@ -8,7 +8,6 @@ from dj.choices.fields import ChoiceField
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
-from django.core.validators import RegexValidator
 from django.db import models, transaction
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
@@ -114,6 +113,9 @@ class SubDomainValidator():
                 )
         # Fallthrough - ALLOW - we don't manage any superdomain
         return domain_name
+
+    def __eq__(self, other):
+        return type(self) == type(other)
 
 
 class WithRequests(models.Model):
@@ -293,6 +295,7 @@ class Record(TimeTrackable, Owned, RecordLike, WithRequests):
     '''
     PowerDNS DNS records
     '''
+    prefix = ''
     RECORD_TYPE = [(r, r) for r in RECORD_TYPES]
     domain = models.ForeignKey(
         Domain,
@@ -460,7 +463,6 @@ class Record(TimeTrackable, Owned, RecordLike, WithRequests):
         s.update(value)
         s.update(salt)
         return s.digest()
-
 
     def force_case(self):
         """Force the name and content case to upper and lower respectively"""

--- a/powerdns/tests/test_requests.py
+++ b/powerdns/tests/test_requests.py
@@ -39,7 +39,8 @@ class TestRequests(unittest.TestCase):
         set_current_user(self.user1)
         request = DomainRequest.objects.create(
             parent_domain=self.domain,
-            name='subdomain.example.com',
+            target_name='subdomain.example.com',
+            target_owner=self.user1,
         )
         request.accept()
         assert_does_exist(
@@ -49,9 +50,10 @@ class TestRequests(unittest.TestCase):
     def test_domain_change(self):
         request = DomainRequest.objects.create(
             domain=self.domain,
-            name='example.com',
-            type='MASTER',
+            target_name='example.com',
+            target_type='MASTER',
             owner=self.user2,
+            target_owner=self.user1,
         )
         request.accept()
         assert_does_exist(
@@ -65,21 +67,26 @@ class TestRequests(unittest.TestCase):
     def test_record_creation(self):
         request = RecordRequest.objects.create(
             domain=self.domain,
-            type='CNAME',
-            name='site.example.com',
-            content='www.example.com',
-            owner=self.user1
+            target_type='CNAME',
+            target_name='site.example.com',
+            target_content='www.example.com',
+            owner=self.user1,
+            target_owner=self.user2,
         )
         request.accept()
-        assert_does_exist(Record, content='www.example.com')
+        assert_does_exist(
+            Record,
+            content='www.example.com',
+            owner=self.user2,
+        )
 
     def test_record_change(self):
         request = RecordRequest.objects.create(
             domain=self.domain,
             record=self.record,
-            type='CNAME',
-            name='forum.example.com',
-            content='djangobb.example.com',
+            target_type='CNAME',
+            target_name='forum.example.com',
+            target_content='djangobb.example.com',
         )
         request.accept()
         assert_does_exist(Record, content='djangobb.example.com')

--- a/powerdns/tests/utils.py
+++ b/powerdns/tests/utils.py
@@ -9,7 +9,6 @@ from rest_framework.test import APIClient
 
 from powerdns.models.powerdns import Record, Domain
 from powerdns.models.templates import RecordTemplate, DomainTemplate
-from powerdns.utils import AutoPtrOptions
 
 
 class DomainFactory(DjangoModelFactory):
@@ -39,6 +38,7 @@ class RecordTestCase(TestCase):
         self.domain = DomainFactory(
             name='example.com',
             template=None,
+            reverse_template=None,
         )
 
     def validate(self, **values):


### PR DESCRIPTION
This is a huge commit to enable changing the owner by jira request.
Previously it was impossible due to the conflict of 'owner' field that
meant the user who issued the request. All the fields that are to be
copied to domain/record are renamed to target_foo now.
