### PR TITLE
Changed the look of deleterequest add form

### DIFF
--- a/powerdns/templates/admin/powerdns/deleterequest/change_form.html
+++ b/powerdns/templates/admin/powerdns/deleterequest/change_form.html
@@ -1,0 +1,11 @@
+{% extends "admin/change_form.html" %}
+{% load i18n %}
+{% block object-tools-items %}
+{{ block.super }}
+{% for btn in original.extra_buttons %} 
+<li><a href="{{ btn.0 }}">{{ btn.1 }}</a></li>
+{% endfor %}
+{% endblock %}
+{% block after_field_sets %}
+{% trans "Request to delete:" %} {{ deleted_item }}
+{% endblock %}


### PR DESCRIPTION
The deleterequest form is already filled when one clicks 'request
deletion'. So we only present neatly the object that is about to be
deleted.
