### PR TITLE
Fixes for CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,13 +1,9 @@
 machine:
-    pre:
-        - echo 'DOCKER_OPTS="-s btrfs -e lxc -D --userland-proxy=false"' | sudo tee -a /etc/default/docker
-        - sudo curl -L -o /usr/bin/docker 'https://s3-external-1.amazonaws.com/circle-downloads/docker-1.8.2-circleci'
-        - sudo chmod 0755 /usr/bin/docker
     services:
         - docker
 dependencies:
     override:
-        - pip install docker-compose
+        - "true" # If we don't override, Circle will try to install in p2.7
 test:
     override:
         - cd integration-tests && docker-compose run runner

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     install_requires = [
         'Django>=1.8',
         'IPy>=0.82a',
-        'django-autocomplete-light>=2.2.10',
+        'django-autocomplete-light==2.3.3',
         'django-extensions>=1.5.5',
         'django-nose>=1.4',
         'dj.choices>=0.10.0',


### PR DESCRIPTION
- A new backwards-incompatible version of django-autocomplete-light is
  out, so we need to keep old one by now.
- CircleCI has now docker-compose installed by default. We don't need to
  install it for them
