### PR TITLE
flake8 and unittests along with integration

### DIFF
--- a/Dockerfile-integration
+++ b/Dockerfile-integration
@@ -1,0 +1,13 @@
+FROM zefciu/python-base
+MAINTAINER Pylabs <pylabs@allegro.pl>
+RUN pip install nose py3dns requests flake8
+RUN mkdir dnsaas-source
+ADD setup.py dnsaas-source/setup.py
+ADD README.rst dnsaas-source/README.rst
+ADD version.json dnsaas-source/version.json
+ADD powerdns dnsaas-source/powerdns
+ADD dnsaas dnsaas-source/dnsaas
+ADD manage.py dnsaas-source/manage.py
+RUN cd dnsaas-source && python3.4 setup.py install 
+ADD integration-tests integration-tests
+CMD /bin/sh integration-tests/runtests.sh

--- a/integration-tests/Dockerfile
+++ b/integration-tests/Dockerfile
@@ -1,6 +1,0 @@
-FROM zefciu/python-base
-MAINTAINER Pylabs <pylabs@allegro.pl>
-RUN pip install nose py3dns requests
-ADD test test
-ADD runtests.sh runtests.sh
-CMD bin/sh runtests.sh

--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -2,7 +2,8 @@
 ---
 
 runner:
-    build: .
+    build: ".."
+    dockerfile: 'Dockerfile-integration'
     links:
         - "dnsaas:dnsaas"
         - "pdns:pdns"

--- a/integration-tests/runtests.sh
+++ b/integration-tests/runtests.sh
@@ -4,4 +4,9 @@ do
     sleep 3
 done
 
+
+cd dnsaas-source &&\
+flake8 --exclude=migrations powerdns &&\
+python3.4 manage.py test &&\
+cd ../integration-tests &&\
 nosetests

--- a/powerdns/admin.py
+++ b/powerdns/admin.py
@@ -284,7 +284,7 @@ class RecordTemplateAdmin(ForeignKeyAutocompleteAdmin):
     list_display = RECORD_LIST_FIELDS
 
 
-class DomainRequestForm(autocomplete_light.ModelForm):
+class DomainRequestForm(autocomplete_light.forms.ModelForm):
     class Meta:
         widgets = {
             'state': HiddenInput(),
@@ -302,7 +302,7 @@ class DomainRequestAdmin(RequestAdmin):
     readonly_fields = ['key']
 
 
-class AuthorisationForm(autocomplete_light.ModelForm):
+class AuthorisationForm(autocomplete_light.forms.ModelForm):
     class Meta:
         model = Authorisation
         fields = [
@@ -365,7 +365,7 @@ class DeleteRequestAdmin(ObjectPermissionsModelAdmin):
         return super().add_view(request, extra_context=extra_context)
 
 
-class RecordRequestForm(autocomplete_light.ModelForm):
+class RecordRequestForm(autocomplete_light.forms.ModelForm):
     class Meta:
         widgets = {
             'state': HiddenInput(),

--- a/powerdns/tests/test_auto_ptr.py
+++ b/powerdns/tests/test_auto_ptr.py
@@ -31,7 +31,7 @@ class TestAutoPtr(TestCase):
                 'ns1.{domain-name} hostmaster.{domain-name} '
                 '0 43200 600 1209600 600'
             ),
-            domain_template = self.reverse_template,
+            domain_template=self.reverse_template,
         )
         self.alt_soa_record = RecordTemplateFactory(
             type='SOA',
@@ -40,7 +40,7 @@ class TestAutoPtr(TestCase):
                 'nameserver1.{domain-name} hostmaster.{domain-name} '
                 '0 43200 1200 1209600 1200'
             ),
-            domain_template = self.alt_reverse_template,
+            domain_template=self.alt_reverse_template,
         )
         self.domain = DomainFactory(
             name='example.com',

--- a/powerdns/tests/test_ownership.py
+++ b/powerdns/tests/test_ownership.py
@@ -1,7 +1,5 @@
 """Tests for record/domain ownership"""
 
-import base64
-
 from django.contrib.auth.models import User
 from django.core import mail
 from django.test import TestCase

--- a/powerdns/tests/test_templates.py
+++ b/powerdns/tests/test_templates.py
@@ -30,7 +30,7 @@ class TestTemplates(TestCase):
                 'ns1.{domain-name} hostmaster.{domain-name} '
                 '0 43200 600 1209600 600'
             ),
-            domain_template = self.domain_template1,
+            domain_template=self.domain_template1,
         )
         self.t1_ns_record = RecordTemplateFactory(
             type='NS',
@@ -38,7 +38,7 @@ class TestTemplates(TestCase):
             content=(
                 'ns1.{domain-name}'
             ),
-            domain_template = self.domain_template1,
+            domain_template=self.domain_template1,
         )
         self.t1_a_record = RecordTemplateFactory(
             type='A',
@@ -46,7 +46,7 @@ class TestTemplates(TestCase):
             content=(
                 '192.168.1.3'
             ),
-            domain_template = self.domain_template1,
+            domain_template=self.domain_template1,
             auto_ptr=AutoPtrOptions.ALWAYS,
         )
         self.domain_template2 = DomainTemplateFactory(name='template2')
@@ -57,7 +57,7 @@ class TestTemplates(TestCase):
                 'nameserver1.{domain-name} hostmaster.{domain-name} '
                 '0 43200 1200 1209600 1200'
             ),
-            domain_template = self.domain_template2,
+            domain_template=self.domain_template2,
         )
         RecordTemplateFactory(
             type='NS',
@@ -65,7 +65,7 @@ class TestTemplates(TestCase):
             content=(
                 'nameserver1.{domain-name}'
             ),
-            domain_template = self.domain_template2,
+            domain_template=self.domain_template2,
         )
         RecordTemplateFactory(
             type='NS',
@@ -73,7 +73,7 @@ class TestTemplates(TestCase):
             content=(
                 'nameserver2.{domain-name}'
             ),
-            domain_template = self.domain_template2,
+            domain_template=self.domain_template2,
         )
 
     def test_record_creation(self):
@@ -170,7 +170,7 @@ class TestTemplates(TestCase):
             content=(
                 'ns2.{domain-name}'
             ),
-            domain_template = self.domain_template1,
+            domain_template=self.domain_template1,
         )
         self.assertEqual(domain.record_set.count(), 4)
         assert_does_exist(Record, domain=domain, content='ns2.example.com')


### PR DESCRIPTION
With this patch, circleCI will perform flake8 and unittests, not only
integration tests.
- Corrected some flake8 errors
- For some reason ModelForm from autocomplete_light failed in docker
  (it works in every other situation that I tested), so used more direct
  import.
