### PR TITLE
Fix migrations to support postgres

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ testem.log
 .DS_Store
 ui/static/dist/
 ui/static/lib/
+
+/settings_local.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM zefciu/dnsaas-base
 MAINTAINER Pylabs <pylabs@allegro.pl>
+RUN pip install mysqlclient==1.3.7
 RUN mkdir dnsaas
 ADD dnsaas dnsaas/dnsaas
 ADD powerdns dnsaas/powerdns

--- a/Dockerfile-integration
+++ b/Dockerfile-integration
@@ -1,6 +1,7 @@
 FROM zefciu/python-base
 MAINTAINER Pylabs <pylabs@allegro.pl>
 RUN pip install nose py3dns requests flake8
+RUN pip install mysqlclient==1.3.7
 RUN mkdir dnsaas-source
 ADD setup.py dnsaas-source/setup.py
 ADD Makefile dnsaas-source/Makefile
@@ -10,6 +11,6 @@ ADD powerdns dnsaas-source/powerdns
 ADD dnsaas dnsaas-source/dnsaas
 ADD ui dnsaas-source/ui
 ADD manage.py dnsaas-source/manage.py
-RUN cd dnsaas-source && python3.4 setup.py install 
+RUN cd dnsaas-source && python3.4 setup.py install
 ADD integration-tests integration-tests
 CMD /bin/sh integration-tests/runtests.sh

--- a/powerdns/migrations/0009_auto_20150915_0342.py
+++ b/powerdns/migrations/0009_auto_20150915_0342.py
@@ -7,6 +7,18 @@ import django.core.validators
 import dj.choices.fields
 
 
+class PostgresOnlyRunSQL(migrations.RunSQL):
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        if not schema_editor.connection.vendor.startswith('postgres'):
+            return
+        super(PostgresOnlyRunSQL, self).database_forwards(app_label, schema_editor, from_state, to_state)
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        if not schema_editor.connection.vendor.startswith('postgres'):
+            return
+        super(PostgresOnlyRunSQL, self).database_backwards(app_label, schema_editor, from_state, to_state)
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -19,14 +31,42 @@ class Migration(migrations.Migration):
             name='name',
             field=models.CharField(unique=True, verbose_name='name', max_length=255, validators=[django.core.validators.RegexValidator('^([A-Za-z0-9-]+\\.)*([A-Za-z0-9])+$')]),
         ),
+        PostgresOnlyRunSQL(
+            (
+                "ALTER TABLE records ALTER COLUMN auto_ptr TYPE INTEGER USING auto_ptr::integer, ALTER COLUMN auto_ptr SET DEFAULT 1;",
+                "ALTER TABLE records ALTER COLUMN auto_ptr DROP DEFAULT;",
+            ),
+            migrations.RunSQL.noop
+        ),
         migrations.AlterField(
             model_name='record',
             name='auto_ptr',
             field=dj.choices.fields.ChoiceField(default=2, choices=powerdns.utils.AutoPtrOptions, verbose_name='Auto PTR record'),
         ),
+        PostgresOnlyRunSQL(
+            migrations.RunSQL.noop,
+            (
+                "ALTER TABLE records ALTER COLUMN auto_ptr TYPE BOOLEAN USING CASE WHEN auto_ptr = 0 THEN FALSE ELSE TRUE END, ALTER COLUMN auto_ptr SET DEFAULT TRUE;",
+                "ALTER TABLE records ALTER COLUMN auto_ptr DROP DEFAULT;",
+            )
+        ),
+        PostgresOnlyRunSQL(
+            (
+                "ALTER TABLE powerdns_recordtemplate ALTER COLUMN auto_ptr TYPE INTEGER USING auto_ptr::integer, ALTER COLUMN auto_ptr SET DEFAULT 1;",
+                "ALTER TABLE powerdns_recordtemplate ALTER COLUMN auto_ptr DROP DEFAULT;",
+            ),
+            migrations.RunSQL.noop
+        ),
         migrations.AlterField(
             model_name='recordtemplate',
             name='auto_ptr',
             field=dj.choices.fields.ChoiceField(default=2, choices=powerdns.utils.AutoPtrOptions, verbose_name='Auto PTR field'),
+        ),
+        PostgresOnlyRunSQL(
+            migrations.RunSQL.noop,
+            (
+                "ALTER TABLE powerdns_recordtemplate ALTER COLUMN auto_ptr TYPE BOOLEAN USING CASE WHEN auto_ptr = 0 THEN FALSE ELSE TRUE END, ALTER COLUMN auto_ptr SET DEFAULT TRUE;",
+                "ALTER TABLE powerdns_recordtemplate ALTER COLUMN auto_ptr DROP DEFAULT;",
+            )
         ),
     ]

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
         'django-extensions>=1.5.5',
         'django-nose>=1.4',
         'dj.choices>=0.10.0',
-        'mysqlclient==1.3.7',
         'nose-cov>=1.6',
         'factory_boy>=2.5.2',
         # 3.3.3 includes bug, https://github.com/rtfd/readthedocs.org/issues/2101
@@ -65,5 +64,9 @@ setup(
         'rules>=0.4',
         'raven==5.20.0'
     ],
+    extras_requires={
+        'mysql': ['mysqlclient'],
+        'postgresql': ['psycopg2'],
+    },
     zip_safe = False,  # if only because of the readme file
 )


### PR DESCRIPTION
Postgres has boolean data type and it is not implicitly castable to integer, so migration 0009_... fails
