### PR TITLE
Decouple powerdns model imports

### DIFF
--- a/dnsaas/admin.py
+++ b/dnsaas/admin.py
@@ -5,27 +5,23 @@ from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth import get_user_model
 from django.db import models
 from django.forms import NullBooleanSelect
-from powerdns.models.requests import (
+from powerdns.models import (
+    CryptoKey,
     DeleteRequest,
+    Domain,
+    DomainMetadata,
     DomainRequest,
+    DomainTemplate,
+    Record,
     RecordRequest,
+    RecordTemplate,
+    Service,
+    ServiceOwner,
+    SuperMaster,
+    TsigKey,
 )
 from django.utils.translation import ugettext_lazy as _
 from django_extensions.admin import ForeignKeyAutocompleteAdmin
-
-from powerdns.models.powerdns import (
-    CryptoKey,
-    Domain,
-    DomainMetadata,
-    Record,
-    SuperMaster,
-)
-from powerdns.models.ownership import Service, ServiceOwner
-from powerdns.models.templates import (
-    DomainTemplate,
-    RecordTemplate,
-)
-from powerdns.models.tsigkeys import TsigKey
 
 
 RECORD_LIST_FIELDS = (

--- a/dnsaas/api/v1/serializers.py
+++ b/dnsaas/api/v1/serializers.py
@@ -9,6 +9,7 @@ from powerdns.models import (
     RecordRequest,
     RecordTemplate,
     SuperMaster,
+    TsigKey,
 )
 from rest_framework.serializers import (
     HyperlinkedModelSerializer,
@@ -17,7 +18,6 @@ from rest_framework.serializers import (
     ReadOnlyField,
 )
 from powerdns.utils import DomainForRecordValidator
-from powerdns.models.tsigkeys import TsigKey
 
 
 class OwnerSerializer(HyperlinkedModelSerializer):

--- a/dnsaas/api/v1/views.py
+++ b/dnsaas/api/v1/views.py
@@ -3,6 +3,8 @@
 from django.db.models import Q
 
 from powerdns.models import (
+    can_delete,
+    can_edit,
     CryptoKey,
     Domain,
     DomainMetadata,
@@ -10,8 +12,8 @@ from powerdns.models import (
     Record,
     RecordTemplate,
     SuperMaster,
+    TsigKey,
 )
-from powerdns.models.powerdns import can_delete, can_edit
 from rest_framework import exceptions
 from rest_framework.filters import DjangoFilterBackend
 from rest_framework.viewsets import ModelViewSet
@@ -28,7 +30,6 @@ from .serializers import (
     TsigKeysTemplateSerializer,
 )
 from powerdns.utils import to_reverse
-from powerdns.models.tsigkeys import TsigKey
 
 
 class DomainPermission(DjangoObjectPermissions):

--- a/dnsaas/api/v2/serializers.py
+++ b/dnsaas/api/v2/serializers.py
@@ -11,7 +11,9 @@ from powerdns.models import (
     Record,
     RecordRequest,
     RecordTemplate,
+    RequestStates,
     SuperMaster,
+    TsigKey,
 )
 from rest_framework import serializers
 from rest_framework.serializers import (
@@ -20,8 +22,6 @@ from rest_framework.serializers import (
     ModelSerializer,
     SlugRelatedField,
 )
-from powerdns.models.requests import RequestStates
-from powerdns.models.tsigkeys import TsigKey
 
 
 class OwnerSerializer(ModelSerializer):

--- a/dnsaas/api/v2/tests.py
+++ b/dnsaas/api/v2/tests.py
@@ -9,9 +9,9 @@ from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APIClient, APIRequestFactory
 
-from powerdns.models.powerdns import Record
-from powerdns.models.requests import (
+from powerdns.models import (
     DeleteRequest,
+    Record,
     RecordRequest,
     RequestStates,
 )

--- a/dnsaas/api/v2/views.py
+++ b/dnsaas/api/v2/views.py
@@ -11,6 +11,7 @@ from django.db.models import Prefetch, Q
 
 from powerdns.utils import hostname2domain
 from powerdns.models import (
+    can_auto_accept_record_request,
     CryptoKey,
     DeleteRequest,
     Domain,
@@ -19,7 +20,9 @@ from powerdns.models import (
     Record,
     RecordTemplate,
     RecordRequest,
+    RequestStates,
     SuperMaster,
+    TsigKey,
 )
 from rest_framework import filters, status
 from rest_framework.permissions import DjangoObjectPermissions, IsAdminUser
@@ -39,11 +42,6 @@ from .serializers import (
     TsigKeysTemplateSerializer,
 )
 from powerdns.utils import to_reverse
-from powerdns.models.tsigkeys import TsigKey
-from powerdns.models.requests import (
-    RequestStates,
-    can_auto_accept_record_request,
-)
 
 
 log = logging.getLogger(__name__)

--- a/powerdns/apps.py
+++ b/powerdns/apps.py
@@ -10,7 +10,7 @@ class Powerdns(AppConfig):
 
     def ready(self):
         import autocomplete_light.shortcuts as al
-        from powerdns.models.powerdns import Domain, Record
+        from powerdns.models import Domain, Record
 
         class AutocompleteAuthItems(al.AutocompleteGenericBase):
             choices = (

--- a/powerdns/models/__init__.py
+++ b/powerdns/models/__init__.py
@@ -1,4 +1,6 @@
-from powerdns.models.powerdns import *  # noqa
-from powerdns.models.templates import *  # noqa
 from powerdns.models.authorisations import *  # noqa
+from powerdns.models.ownership import *  # noqa
+from powerdns.models.powerdns import *  # noqa
 from powerdns.models.requests import *  # noqa
+from powerdns.models.templates import *  # noqa
+from powerdns.models.tsigkeys import *  # noqa

--- a/powerdns/models/powerdns.py
+++ b/powerdns/models/powerdns.py
@@ -82,6 +82,7 @@ def get_ptr_obj(ip, content):
 
 def get_default_reverse_domain():
     """Returns a default reverse domain."""
+    # Avoid circular import (.templates imports this file)
     from powerdns.models.templates import DomainTemplate
     global DEFAULT_REVERSE_DOMAIN_TEMPLATE
     if not DEFAULT_REVERSE_DOMAIN_TEMPLATE:

--- a/powerdns/tests/test_auto_ptr.py
+++ b/powerdns/tests/test_auto_ptr.py
@@ -5,7 +5,7 @@ from unittest import mock
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-from powerdns.models.powerdns import Domain, Record
+from powerdns.models import Domain, Record
 from powerdns.tests.utils import (
     DomainFactory,
     DomainTemplateFactory,

--- a/powerdns/tests/test_ownership.py
+++ b/powerdns/tests/test_ownership.py
@@ -4,11 +4,12 @@ from django.contrib.auth import get_user_model
 from django.core import mail
 from django.test import TestCase
 
-from powerdns.models.powerdns import Domain, Record
-from powerdns.models.requests import (
+from powerdns.models import (
+    can_auto_accept_record_request,
+    Domain,
+    Record,
     RecordRequest,
     RequestStates,
-    can_auto_accept_record_request,
 )
 from powerdns.tests.utils import (
     DomainFactory,

--- a/powerdns/tests/test_permissions.py
+++ b/powerdns/tests/test_permissions.py
@@ -6,7 +6,7 @@ from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 
-from powerdns.models.authorisations import Authorisation
+from powerdns.models import Authorisation
 from powerdns.utils import AutoPtrOptions
 
 from powerdns.tests.utils import (

--- a/powerdns/tests/test_request_uniqueness_constraints.py
+++ b/powerdns/tests/test_request_uniqueness_constraints.py
@@ -4,9 +4,8 @@
 # The record requests should be validated like records
 from django.contrib.auth import get_user_model
 
-from powerdns.models.powerdns import Domain, Record
+from powerdns.models import Domain, Record, RecordRequest
 from powerdns.tests.utils import RecordFactory, RecordTestCase
-from powerdns.models.requests import RecordRequest
 
 
 class TestRequestUniquenessConstraints(RecordTestCase):

--- a/powerdns/tests/test_requests.py
+++ b/powerdns/tests/test_requests.py
@@ -3,8 +3,12 @@ from django.test import TestCase
 from threadlocals.threadlocals import set_current_user
 from django.contrib.auth import get_user_model
 
-from powerdns.models.powerdns import Domain, Record
-from powerdns.models.requests import DomainRequest, RecordRequest
+from powerdns.models import (
+    Domain,
+    DomainRequest,
+    Record,
+    RecordRequest,
+)
 from powerdns.tests.utils import assert_does_exist, assert_not_exists
 
 

--- a/powerdns/tests/test_templates.py
+++ b/powerdns/tests/test_templates.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 
 from django.test import TestCase
 
-from powerdns.models.powerdns import Domain, Record
+from powerdns.models import Domain, Record
 from powerdns.tests.utils import (
     DomainTemplateFactory,
     RecordFactory,

--- a/powerdns/tests/utils.py
+++ b/powerdns/tests/utils.py
@@ -10,10 +10,16 @@ from django.test import TestCase
 from factory.django import DjangoModelFactory
 from rest_framework.test import APIClient
 
-from powerdns.models.powerdns import Record, Domain
-from powerdns.models.requests import DeleteRequest, RecordRequest
-from powerdns.models.ownership import ServiceOwner, Service
-from powerdns.models.templates import RecordTemplate, DomainTemplate
+from powerdns.models import (
+    DeleteRequest,
+    Domain,
+    DomainTemplate,
+    Record,
+    RecordRequest,
+    RecordTemplate,
+    Service,
+    ServiceOwner,
+)
 from powerdns.utils import AutoPtrOptions
 
 

--- a/powerdns/utils.py
+++ b/powerdns/utils.py
@@ -171,7 +171,7 @@ class PermissionValidator():
         super().__init__(*args, **kwargs)
 
     def __call__(self, object_):
-        from powerdns.models.powerdns import can_edit
+        from powerdns.models import can_edit
         if not can_edit(get_current_user(), object_):
             raise ValidationError("You don't have permission to use this")
         return object_


### PR DESCRIPTION
...from the implementation detail of where they are actually defined.

Split out from #166.

This PR removes imports to submodules of `powerdns.models`, because I think that inappropriately couples code to implementation details. Consider what would happen if the `CryptoKey` model was moved from `powerdns/models.powerdns.py` to `powerdns/models/tsigkeys.py` - every single `from powerdns.models.powerdns import CryptoKey` would need to be refactored to `from powerdns.models.tsigkeys import CryptoKey`.

Here's an illustration:

`powerdns/models/__init__.py`:

``` python
...
from .powerdns import *  # this works too: from powerdns.models.powerdns import *
...
from .tsigkeys import *  # this works too: from powerdns.models.tsigkeys import *
```

``` python
from powerdns.models.powerdns import CryptoKey  # <-- works
from powerdns.models import CryptoKey  # <-- works
```

but once `CryptoKey` is moved from `powerdns/models/powerdns.py` to `powerdns/models/tsigkeys.py`:

``` python
from powerdns.models.powerdns import CryptoKey  # <-- breaks!
from powerdns.models import CryptoKey  # <-- still works
```
