### PR TITLE
Move VERSION into dnsaas since it's not used anywhere in powerdns

### DIFF
--- a/dnsaas/urls.py
+++ b/dnsaas/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import patterns, include, url
 from django.contrib import admin
 from django.conf import settings
 
-from powerdns.utils import VERSION
+from dnsaas.utils import VERSION
 from powerdns.views import obtain_auth_token
 from ui.views import start_page
 

--- a/dnsaas/utils.py
+++ b/dnsaas/utils.py
@@ -1,0 +1,10 @@
+from pkg_resources import working_set, Requirement
+
+
+try:
+    req = Requirement.parse('django-powerdns-dnssec')
+    VERSION = working_set.find(req).version
+except AttributeError:
+    import json
+    with open('version.json') as f:
+        VERSION = '.'.join(str(part) for part in json.load(f))

--- a/powerdns/utils.py
+++ b/powerdns/utils.py
@@ -1,7 +1,6 @@
 """Utilities for powerdns models"""
 
 import ipaddress
-from pkg_resources import working_set, Requirement
 
 import rules
 from django.conf import settings
@@ -17,9 +16,6 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from threadlocals.threadlocals import get_current_user
 from dj.choices import Choices
-
-
-VERSION = working_set.find(Requirement.parse('django-powerdns-dnssec')).version
 
 
 DOMAIN_NAME_RECORDS = ('CNAME', 'MX', 'NAPTR', 'NS', 'PTR')


### PR DESCRIPTION
This change allows people (me) to git clone this repo and only use the powerdns app.

Otherwise, loading the version in `powerdns/utils.py` raises a `FileNotFoundError` because `version.json` doesn't exist anywhere.
