### PR TITLE
Add timestamps to requests

### DIFF
--- a/dnsaas/api/v2/serializers.py
+++ b/dnsaas/api/v2/serializers.py
@@ -59,6 +59,13 @@ class RecordRequestSerializer(OwnerSerializer):
         required=False,
     )
 
+    created = serializers.DateTimeField(
+        format='%Y-%m-%d %H:%M:%S', read_only=True
+    )
+    modified = serializers.DateTimeField(
+        format='%Y-%m-%d %H:%M:%S', read_only=True
+    )
+
     class Meta:
         model = RecordRequest
 

--- a/powerdns/admin.py
+++ b/powerdns/admin.py
@@ -187,18 +187,20 @@ class ReadonlyAdminMixin(object):
 
 class DeleteRequestAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     model = DeleteRequest
-    fields = ['owner', 'target_id', 'content_type']
+    list_display = ['content_type', 'state', 'created']
+    fields = ['owner', 'target_id', 'content_type', 'state', 'created']
 
 
 class DomainRequestAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     model = DomainRequest
-    list_display = ['domain']
+    list_display = ['domain', 'state', 'created']
     fields = [
         'domain',
         'key',
         'last_change_json',
         'parent_domain',
         'state',
+        'created',
         'target_account',
         'target_auto_ptr',
         'target_master',
@@ -214,13 +216,15 @@ class DomainRequestAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
 
 class RecordRequestAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     model = RecordRequest
-    list_display = ['target_' + field for field in RECORD_LIST_FIELDS]
+    list_display = ['target_' + field for field in RECORD_LIST_FIELDS] + \
+                   ['state', 'created']
     fields = [
         'domain',
         'key',
         'last_change_json',
         'record',
         'state',
+        'created',
         'target_auth',
         'target_content',
         'target_disabled',
@@ -241,11 +245,13 @@ class OwnerInline(admin.TabularInline):
 
 @admin.register(Service)
 class ServiceAdmin(admin.ModelAdmin):
+    list_display = ['__str__', 'is_active']
     inlines = (OwnerInline,)
 
 
 @admin.register(ServiceOwner)
 class ServiceOwnerAdmin(admin.ModelAdmin):
+    list_display = ['owner', 'ownership_type', 'service']
     raw_id_fields = ("service", 'owner')
 
 

--- a/powerdns/admin.py
+++ b/powerdns/admin.py
@@ -188,12 +188,15 @@ class ReadonlyAdminMixin(object):
 class DeleteRequestAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     model = DeleteRequest
     list_display = ['content_type', 'state', 'created']
+    list_filter = ('content_type', 'state',)
     fields = ['owner', 'target_id', 'content_type', 'state', 'created']
+    radio_fields = {'content_type': admin.HORIZONTAL}
 
 
 class DomainRequestAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     model = DomainRequest
     list_display = ['domain', 'state', 'created']
+    list_filter = ('state',)
     fields = [
         'domain',
         'key',
@@ -212,12 +215,14 @@ class DomainRequestAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
         'target_type',
         'target_unrestricted',
     ]
+    search_fields = ('domain__name',)
 
 
 class RecordRequestAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     model = RecordRequest
     list_display = ['target_' + field for field in RECORD_LIST_FIELDS] + \
                    ['state', 'created']
+    list_filter = ('state',)
     fields = [
         'domain',
         'key',
@@ -235,6 +240,7 @@ class RecordRequestAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
         'target_ttl',
         'target_type',
     ]
+    search_fields = ('domain__name', 'record__name', 'record__content')
 
 
 class OwnerInline(admin.TabularInline):

--- a/powerdns/migrations/0032_auto_20161102_2006.py
+++ b/powerdns/migrations/0032_auto_20161102_2006.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import datetime
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('powerdns', '0031_auto_20161102_0640'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='deleterequest',
+            name='created',
+            field=models.DateTimeField(auto_now_add=True, verbose_name='date created', default=datetime.datetime(1970, 1, 1, 0, 0)),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='deleterequest',
+            name='modified',
+            field=models.DateTimeField(auto_now=True, verbose_name='last modified', default=datetime.datetime(1970, 1, 1, 0, 0)),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='domainrequest',
+            name='created',
+            field=models.DateTimeField(auto_now_add=True, verbose_name='date created', default=datetime.datetime(1970, 1, 1, 0, 0)),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='domainrequest',
+            name='modified',
+            field=models.DateTimeField(auto_now=True, verbose_name='last modified', default=datetime.datetime(1970, 1, 1, 0, 0)),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='recordrequest',
+            name='created',
+            field=models.DateTimeField(auto_now_add=True, verbose_name='date created', default=datetime.datetime(1970, 1, 1, 0, 0)),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='recordrequest',
+            name='modified',
+            field=models.DateTimeField(auto_now=True, verbose_name='last modified', default=datetime.datetime(1970, 1, 1, 0, 0)),
+            preserve_default=False,
+        ),
+    ]

--- a/powerdns/models/ownership.py
+++ b/powerdns/models/ownership.py
@@ -32,7 +32,7 @@ class Service(TimeTrackable):
     )
 
     def __str__(self):
-        return '{} {} ({})'.format(self.name, self.is_active, self.uid)
+        return '{} ({})'.format(self.name, self.uid)
 
 
 class ServiceOwner(TimeTrackable):

--- a/powerdns/models/requests.py
+++ b/powerdns/models/requests.py
@@ -20,7 +20,8 @@ from powerdns.models import (
     validate_domain_name,
 )
 
-from powerdns.utils import AutoPtrOptions, RecordLike, flat_dict_diff
+from powerdns.utils import \
+    AutoPtrOptions, RecordLike, TimeTrackable, flat_dict_diff
 
 
 log = logging.getLogger(__name__)
@@ -69,7 +70,7 @@ class RequestStates(Choices):
     REJECTED = _('Rejected')
 
 
-class Request(Owned):
+class Request(Owned, TimeTrackable):
     """Abstract request"""
 
     class Meta:

--- a/ui/static/app/record-request/record-request-detail.component.html
+++ b/ui/static/app/record-request/record-request-detail.component.html
@@ -42,6 +42,10 @@
           <td [innerHTML]="getValue('remarks')"></td>
         </tr>
         <tr>
+          <td>Created</td>
+          <td>{{ recordRequest.created }}</td>
+        </tr>
+        <tr>
           <td>Domain</td>
           <td>{{ domain.name }}</td>
         </tr>

--- a/ui/static/app/record-request/record-request.component.html
+++ b/ui/static/app/record-request/record-request.component.html
@@ -21,6 +21,7 @@
             <th>Content</th>
             <th>TTL</th>
             <th>Owner</th>
+            <th>Created</th>
             <th>Ticket</th>
             <th>Options</th>
          </tr>
@@ -45,6 +46,9 @@
           </td>
           <td>
             {{ request.target_owner }}
+          </td>
+          <td>
+            {{ request.created }}
           </td>
           <td>
             <a href="{{ jiraUrl }}/browse/{{ request.key }}" target="_blank" *ngIf="request.key"> {{ request.key }} </a>

--- a/ui/static/app/record-request/record-request.ts
+++ b/ui/static/app/record-request/record-request.ts
@@ -9,6 +9,7 @@ export class RecordRequest {
   target_ttl: string;
   target_auth: string;
   target_remarks: string;
+  created: string;
   domain: number;
   record: number;
   last_change: JSON;


### PR DESCRIPTION
Added timestamps to requests to easier distinguish them in requests lists (in v2 API, UI and django admin).

Also added couple of columns in django admin with necessary info:
* state of requests
* type of delete requests
* separated 'owner', 'ownership_type', 'service' by 3 columns instead of one