### PR TITLE
PostgreSQL support

### DIFF
--- a/powerdns/migrations/0006_auto_20150612_0756.py
+++ b/powerdns/migrations/0006_auto_20150612_0756.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='record',
             name='auto_ptr',
-            field=models.BooleanField(verbose_name='Auto PTR field', default=True),
+            field=models.IntegerField(verbose_name='Auto PTR field', default=2),
             preserve_default=True,
         ),
         migrations.AddField(

--- a/powerdns/migrations/0008_auto_20150821_0630.py
+++ b/powerdns/migrations/0008_auto_20150821_0630.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='recordtemplate',
             name='auto_ptr',
-            field=models.BooleanField(default=True, verbose_name='Auto PTR field'),
+            field=models.IntegerField(default=2, verbose_name='Auto PTR field'),
         ),
         migrations.AlterField(
             model_name='domain',


### PR DESCRIPTION
Change in historical migrations for PostgreSQL support.
Change BooleanField to IntegerField (auto_ptr field was first BooleanField, but in migration 0009 it was changed to IntegerField and psql does not handle changing (casting) bool to integer).

(Much more simpler) alternative for #138 . @blag @iavael could you check if it is working for you?