### PR TITLE
Fix creating PTR for IPv6 (AAAA) records

### DIFF
--- a/dnsaas/api/v1/views.py
+++ b/dnsaas/api/v1/views.py
@@ -29,7 +29,7 @@ from .serializers import (
     SuperMasterSerializer,
     TsigKeysTemplateSerializer,
 )
-from powerdns.utils import to_reverse
+from powerdns.utils import reverse_pointer
 
 
 class DomainPermission(DjangoObjectPermissions):
@@ -91,7 +91,7 @@ class RecordViewSet(OwnerViewSet):
         if ips:
             a_records = Record.objects.filter(content__in=ips, type='A')
             ptrs = [
-                "{1}.{0}".format(*to_reverse(r.content)) for r in a_records
+                reverse_pointer(r.content) for r in a_records
             ]
             queryset = queryset.filter(
                 (Q(content__in=[r.content for r in a_records]) & Q(type='A')) |

--- a/dnsaas/api/v2/views.py
+++ b/dnsaas/api/v2/views.py
@@ -43,7 +43,7 @@ from .serializers import (
     SuperMasterSerializer,
     TsigKeysTemplateSerializer,
 )
-from powerdns.utils import to_reverse
+from powerdns.utils import reverse_pointer
 
 
 log = logging.getLogger(__name__)
@@ -272,7 +272,7 @@ class RecordViewSet(OwnerViewSet):
         if ips:
             a_records = Record.objects.filter(content__in=ips, type='A')
             ptrs = [
-                "{1}.{0}".format(*to_reverse(r.content)) for r in a_records
+                reverse_pointer(r.content) for r in a_records
             ]
             queryset = queryset.filter(
                 (Q(content__in=[r.content for r in a_records]) & Q(type='A')) |

--- a/dnsaas/settings.py
+++ b/dnsaas/settings.py
@@ -20,8 +20,8 @@ DATABASES = {
         'NAME': 'dnsaas',
         'USER': os.environ.get('DNSAAS_DB_USER', 'dnsaas'),
         'PASSWORD': os.environ.get('DNSAAS_DB_PASSWORD', 'dnsaas'),
-        'HOST': os.environ.get('DNSAAS_DB_HOST', 'localhost'),
-        'PORT': '3306',
+        'HOST': os.environ.get('DNSAAS_DB_HOST', '127.0.0.1'),
+        'PORT': os.environ.get('DNSAAS_DB_PORT', '3306'),
         'TEST': {
             'NAME': 'test_dnsaas',
         },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,21 +3,24 @@
 
 dnsaas:
     build: .
-    ports: 
+    ports:
         - "8080:8080"
-    links: 
-        - mysql:db
+    links:
+        - db:db
 pdns:
     build: docker/pdns
     ports:
         - "5353:53"
         - "5353:53/udp"
     links:
-        - mysql:db
-mysql:
+        - db:db
+
+db:
     image: "drakedroid/mysql-with-data"
     environment:
         MYSQL_ROOT_PASSWORD: root
         MYSQL_USER: dnsaas
         MYSQL_DATABASE: dnsaas
         MYSQL_PASSWORD: dnsaas
+    ports:
+        - "33066:3306"

--- a/powerdns/models/powerdns.py
+++ b/powerdns/models/powerdns.py
@@ -572,9 +572,12 @@ class Record(
             current_ptr.delete()
 
     def create_ptr(self):
-        """Creates a PTR record for A record creating a domain if necessary."""
+        """
+        Creates a PTR record for A or AAAA record creating a domain if
+        necessary.
+        """
         if self.type not in IP_TYPES_FOR_PTR:
-            raise ValueError(_('Creating PTR only for A records'))
+            raise ValueError(_('Creating PTR only for A or AAAA records'))
         number, domain_name = to_reverse(self.content)
         if self.domain.auto_ptr == AutoPtrOptions.ALWAYS:
             domain, created = Domain.objects.get_or_create(

--- a/powerdns/tests/test_utils.py
+++ b/powerdns/tests/test_utils.py
@@ -1,0 +1,31 @@
+from django.test import TestCase
+
+from powerdns.utils import to_reverse, reverse_pointer
+
+
+class TestReversing(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.ipv4 = '192.168.1.2'
+        cls.ipv6 = '2001:0db8:0:0::1428:57ab'
+
+    def test_reversing_pointer_ipv4(self):
+        rev = reverse_pointer(self.ipv4)
+        self.assertEqual(rev, '2.1.168.192.in-addr.arpa')
+
+    def test_reversing_pointer_ipv6(self):
+        rev = reverse_pointer(self.ipv6)
+        self.assertEqual(
+            rev, 'b.a.7.5.8.2.4.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa'  # noqa
+        )
+
+    def test_to_reverse_ipv4(self):
+        last_byte, domain = to_reverse(self.ipv4)
+        self.assertEqual(domain, '1.168.192.in-addr.arpa')
+        self.assertEqual(last_byte, '2')
+
+    def test_to_reverse_ipv6(self):
+        last_byte, domain = to_reverse(self.ipv6)
+        self.assertEqual(domain, 'a.7.5.8.2.4.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa')  # noqa
+        self.assertEqual(last_byte, 'b')


### PR DESCRIPTION
* PTR record is now properly handled (created/updated/deleted) for IPv6 records (AAAA)
* unification of `to_reverse` and `reverse_pointer` - now they both properly handle IPv6 and share the same logic
* improved docker-compose
* add tests for reversion utils and PTR for IPv6