### PR TITLE
Fix 'DateTimeField received a naive datetime' warnings

### DIFF
--- a/powerdns/migrations/0032_auto_20161102_2006.py
+++ b/powerdns/migrations/0032_auto_20161102_2006.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
+from django.utils import timezone
 import datetime
 
 
@@ -15,37 +16,37 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='deleterequest',
             name='created',
-            field=models.DateTimeField(auto_now_add=True, verbose_name='date created', default=datetime.datetime(1970, 1, 1, 0, 0)),
+            field=models.DateTimeField(auto_now_add=True, verbose_name='date created', default=datetime.datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)),
             preserve_default=False,
         ),
         migrations.AddField(
             model_name='deleterequest',
             name='modified',
-            field=models.DateTimeField(auto_now=True, verbose_name='last modified', default=datetime.datetime(1970, 1, 1, 0, 0)),
+            field=models.DateTimeField(auto_now=True, verbose_name='last modified', default=datetime.datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)),
             preserve_default=False,
         ),
         migrations.AddField(
             model_name='domainrequest',
             name='created',
-            field=models.DateTimeField(auto_now_add=True, verbose_name='date created', default=datetime.datetime(1970, 1, 1, 0, 0)),
+            field=models.DateTimeField(auto_now_add=True, verbose_name='date created', default=datetime.datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)),
             preserve_default=False,
         ),
         migrations.AddField(
             model_name='domainrequest',
             name='modified',
-            field=models.DateTimeField(auto_now=True, verbose_name='last modified', default=datetime.datetime(1970, 1, 1, 0, 0)),
+            field=models.DateTimeField(auto_now=True, verbose_name='last modified', default=datetime.datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)),
             preserve_default=False,
         ),
         migrations.AddField(
             model_name='recordrequest',
             name='created',
-            field=models.DateTimeField(auto_now_add=True, verbose_name='date created', default=datetime.datetime(1970, 1, 1, 0, 0)),
+            field=models.DateTimeField(auto_now_add=True, verbose_name='date created', default=datetime.datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)),
             preserve_default=False,
         ),
         migrations.AddField(
             model_name='recordrequest',
             name='modified',
-            field=models.DateTimeField(auto_now=True, verbose_name='last modified', default=datetime.datetime(1970, 1, 1, 0, 0)),
+            field=models.DateTimeField(auto_now=True, verbose_name='last modified', default=datetime.datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)),
             preserve_default=False,
         ),
     ]


### PR DESCRIPTION
Fixes these warnings:

    .../django/db/models/fields/__init__.py:1430: RuntimeWarning: DateTimeField DeleteRequest.created received a naive datetime (1970-01-01 00:00:00) while time zone support is active.
      RuntimeWarning)
    .../django/db/models/fields/__init__.py:1430: RuntimeWarning: DateTimeField DeleteRequest.created received a naive datetime (1970-01-01 00:00:00) while time zone support is active.
      RuntimeWarning)
    .../django/db/models/fields/__init__.py:1430: RuntimeWarning: DateTimeField DomainRequest.created received a naive datetime (1970-01-01 00:00:00) while time zone support is active.
      RuntimeWarning)
    .../django/db/models/fields/__init__.py:1430: RuntimeWarning: DateTimeField DomainRequest.created received a naive datetime (1970-01-01 00:00:00) while time zone support is active.
      RuntimeWarning)
    .../django/db/models/fields/__init__.py:1430: RuntimeWarning: DateTimeField RecordRequest.created received a naive datetime (1970-01-01 00:00:00) while time zone support is active.
      RuntimeWarning)
    .../django/db/models/fields/__init__.py:1430: RuntimeWarning: DateTimeField RecordRequest.created received a naive datetime (1970-01-01 00:00:00) while time zone support is active.
      RuntimeWarning)

when running tests with `USE_TZ = True` in a project `settings.py`.