### PR TITLE
Add optional `service_uid` field to /api/v2/records

### DIFF
--- a/dnsaas/api/v2/tests.py
+++ b/dnsaas/api/v2/tests.py
@@ -1058,6 +1058,29 @@ class TestIPRecordTest(BaseApiTestCase):
         response = self._send_post_data_to_endpoint()
         self.assertEqual(response.status_code, 200)
 
+    def test_add_record_when_service_uid_was_provided(self):
+        service = ServiceFactory()
+        self.data.update({
+            'old': {
+                'address': '127.0.1.1',
+                'hostname': 'test123.example.com'
+            },
+            'new': {
+                'address': '127.0.1.1',
+                'hostname': 'test123.example.com'
+            },
+            'service_uid': service.uid
+        })
+        response = self._send_post_data_to_endpoint()
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            Record.objects.filter(
+                name='test123.example.com',
+                content='127.0.1.1',
+                service=service
+            ).exists()
+        )
+
     def test_create_duplicate_record(self):
         self.data.update({
             'old': {
@@ -1263,7 +1286,7 @@ class TestServiceField(BaseApiTestCase):
             service=None,
         )
 
-    def test_create_record_saves_service(self):
+    def test_create_record_saves_service_by_service_pk(self):
         self.client.login(
             username='owner_with_access', password='owner_with_access'
         )
@@ -1277,7 +1300,27 @@ class TestServiceField(BaseApiTestCase):
                 'name': 'example.com',
                 'content': '192.168.0.1',
                 'service': service.id,
+            },
+        )
 
+        record = Record.objects.get(pk=response.data['id'])
+        self.assertEqual(record.service.id, service.id)
+        self.assertEqual(response.data['service'], service.id)
+
+    def test_create_record_saves_service_by_service_uid(self):
+        self.client.login(
+            username='owner_with_access', password='owner_with_access'
+        )
+        service = ServiceFactory()
+
+        response = self.send_post(
+            reverse('api:v2:record-list'),
+            {
+                'type': 'A',
+                'domain': self.domain.id,
+                'name': 'example.com',
+                'content': '192.168.0.1',
+                'service_uid': service.uid,
             },
         )
 
@@ -1301,7 +1344,12 @@ class TestServiceField(BaseApiTestCase):
         )
 
         self.assertEqual(
-            response.data['service'], ['This field is required.']
+            response.data['service'],
+            [
+                'Service is required. Please provide DNSaaS internal '
+                'service ID in field `service` or global service UID in '
+                'field `service_uid`.'
+            ]
         )
 
     def test_patch_record_works_when_service_is_empty(self):

--- a/dnsaas/api/v2/views.py
+++ b/dnsaas/api/v2/views.py
@@ -404,9 +404,7 @@ class IPRecordView(APIView):
                 domain=hostname2domain(new['hostname']),
                 number=int(ipaddress.ip_address(new['address'])),
                 content=new['address'],
-                **{
-                    'service': service
-                } if service else {}
+                service=service
             )
         except IntegrityError as e:
             return status.HTTP_409_CONFLICT, str(e)

--- a/dnsaas/api/v2/views.py
+++ b/dnsaas/api/v2/views.py
@@ -44,7 +44,6 @@ from .serializers import (
     SuperMasterSerializer,
     TsigKeysTemplateSerializer,
 )
-from powerdns.models import Service
 from powerdns.utils import reverse_pointer
 
 

--- a/powerdns/models/ownership.py
+++ b/powerdns/models/ownership.py
@@ -34,6 +34,20 @@ class Service(TimeTrackable):
     def __str__(self):
         return '{} ({})'.format(self.name, self.uid)
 
+    @classmethod
+    def get_service_by_uid(cls, uid):
+        """
+        Return service by UID or None If service with specified UID does not
+        exist.
+        """
+
+        try:
+            service = cls.objects.get(uid=uid)
+        except cls.DoesNotExist:
+            return
+        else:
+            return service
+
 
 class ServiceOwner(TimeTrackable):
     service = models.ForeignKey(Service)


### PR DESCRIPTION
Now user can provide service UID instead of internal service ID when creating new record.
Internal service ID is also supported.